### PR TITLE
enable weighting

### DIFF
--- a/R/CreateScoreFun.R
+++ b/R/CreateScoreFun.R
@@ -1,25 +1,25 @@
 #' Create a score function for use in a pim.
-#' 
-#' This function creates a suitable score function for the fitting 
-#' process of a probabilistic index model. 
-#' 
+#'
+#' This function creates a suitable score function for the fitting
+#' process of a probabilistic index model.
+#'
 #' @param Z the model matrix of pseudo-observations
 #' @param Y a vector with the response of the pseudo-observations
-#' @param link a character vector indicating the link function 
+#' @param link a character vector indicating the link function
 #' to be used.
-#' @param W a vector with weights. 
-#' 
+#' @param W a vector with weights.
+#'
 #' @return a function used for estimating the coefficients by
-#' the estimator functions. 
-#' 
+#' the estimator functions.
+#'
 #' @section NOTE: This function is not exported.
 
 CreateScoreFun <-function(Z,Y,
-                          link = c("probit","logit","identity"), 
+                          link = c("probit","logit","identity"),
                           W=NULL)
 {
   link <- match.arg(link)
-  
+
   if (link == "probit") {
     U.func <- function(beta) {
       Zbeta <- c(Z %*% beta)

--- a/R/Estimators.R
+++ b/R/Estimators.R
@@ -89,10 +89,10 @@
 #' @export
 estimator.nleqslv <-
   function(x,y,start=rep(0,ncol(x)), link="logit",
-           construct = NULL, ...){
+           construct = NULL, weights = NULL, ...){
     construct <- if(is.null(construct)) CreateScoreFun else
                     match.fun(construct)
-    fn <- construct(x,y,link)
+    fn <- construct(x,y,link,weights)
 
     res <- nleqslv(start,fn, ...)
 

--- a/R/pim-class.R
+++ b/R/pim-class.R
@@ -1,25 +1,25 @@
 #' Class pim
-#' 
+#'
 #' This class contains the fitting information resulting from a call to
-#' \code{\link{pim}}. 
-#' 
+#' \code{\link{pim}}.
+#'
 #' @slot formula The \code{\link{pim.formula}} object used in the fit
 #' @slot coef a numeric vector with the fitted coefficients
-#' @slot vcov a numeric matrix containing the variance-covariance matrix 
+#' @slot vcov a numeric matrix containing the variance-covariance matrix
 #' of the fitted coefficients
-#' @slot penv a \code{\link{pim.environment}} object containing the 
-#' data used to fit this 
-#' @slot fitted a numeric vector containing the raw fitted 
+#' @slot penv a \code{\link{pim.environment}} object containing the
+#' data used to fit this
+#' @slot fitted a numeric vector containing the raw fitted
 #' @slot link a character vector describing the used link function
 #' @slot estimators a list with the elements \code{coef} and \code{vcov},
 #' containing either a character value with the name of the used estimator,
 #' or the function itself.
-#' @slot model.matrix If \code{keep.data} is set to \code{TRUE} 
-#' while calling \code{\link{pim}} the original model matrix. 
+#' @slot model.matrix If \code{keep.data} is set to \code{TRUE}
+#' while calling \code{\link{pim}} the original model matrix.
 #' Otherwise an empty matrix with 0 rows and columns.
-#' @slot response If \code{keep.data} is set to \code{TRUE} 
+#' @slot response If \code{keep.data} is set to \code{TRUE}
 #' while calling \code{\link{pim}} the original response vector.
-#' Otherwise an empty numeric vector. 
+#' Otherwise an empty numeric vector.
 #' @slot keep.data a logical value indicating whether the original
 #' data is kept in the object. This is set using the argument
 #' \code{keep.data} of the function \code{\link{pim}}.
@@ -34,6 +34,7 @@ setClass(
           vcov = 'matrix',
           penv = 'pim.environment',
           fitted = 'numeric',
+          weights = 'numeric',
           link = 'character',
           estimators = 'list',
           model.matrix = 'matrix',

--- a/R/pim.R
+++ b/R/pim.R
@@ -221,9 +221,14 @@ pim <- function(formula,
 
   names(res$coef) <- colnames(x)
 
+  if(is.null(weights)) {
+    weights <- rep(1, length(y))
+  }
+
   if(!keep.data){
     x <- matrix(nrow=0,ncol=0)
     y <- numeric(0)
+    weights <- numeric(0)
   }
 
   new.pim(
@@ -231,6 +236,7 @@ pim <- function(formula,
     coef = res$coef,
     vcov = res$vcov,
     fitted = res$fitted,
+    weights = weights,
     penv = penv,
     link = link,
     estimators=res$estim,

--- a/R/pim.fit.R
+++ b/R/pim.fit.R
@@ -54,7 +54,8 @@ pim.fit <- function(x,y,link = "logit",
 {
   estimF <- match.fun(estim)
   vcov.estimF <- match.fun(vcov.estim)
-  res <- estimF(x, y, link = link, start=start, ...)
+  # if(! is.null(weights)) {print("flag: pim.fit.R")}
+  res <- estimF(x, y, link = link, weights = weights, start=start, ...)
 
   fits <- x %*% res$coef
   dim(fits) <- NULL

--- a/R/vcov.internal.R
+++ b/R/vcov.internal.R
@@ -3,9 +3,9 @@
 #' These functions serve as preparation functions to calculute the variance-
 #' covariance matrix of a pim using any of the \code{\link{vcov.estimators}}
 #' provided in this package. The result of these preparation functions
-#' is used by the \code{\link{sandwich.estimator}} and 
+#' is used by the \code{\link{sandwich.estimator}} and
 #' \code{\link{score.estimator}} functions respectively.
-#' 
+#'
 #' @param Zbeta fitted values
 #' @param Z design matrix
 #' @param Y pseudo responses
@@ -13,7 +13,7 @@
 #' @param W vector with weights
 #'
 #' @note These functions should NOT be called by the user
-#' 
+#'
 #' @rdname vcov.internal
 #' @name vcov.internal
 #' @aliases U.sandwich U.score
@@ -31,13 +31,13 @@ U.sandwich <- function(Zbeta, Z, Y, link, W=NULL)
     var.PI <- fv*(1-fv)
     var.PI[var.PI == 0] <- 0.01 #correction, not mentioned in the article, low impact
     m.d <- dnorm(Zbeta)
-    m.dd <- -m.d*Zbeta 
+    m.dd <- -m.d*Zbeta
     res <- Y-fv
     U <- Z*m.d*res/var.PI
     if(!is.null(W))
     {
       U<-W * U
-      U.diff <- t(Z)%*% diag(W) %*%(Z*c((var.PI*(m.dd*res - m.d^2) - res*m.d^2*(1-2*fv))/var.PI^2))
+      U.diff <- t(W * Z) %*%(Z*c((var.PI*(m.dd*res - m.d^2) - res*m.d^2*(1-2*fv))/var.PI^2))
     }
     else
     {
@@ -53,7 +53,7 @@ U.sandwich <- function(Zbeta, Z, Y, link, W=NULL)
     if(!is.null(W))
     {
       U<-W * U
-      U.diff <- -t(Z)%*% diag(W) %*%(Z*c(var.PI))
+      U.diff <- -t(W * Z) %*%(Z*c(var.PI))
     }
     else
     {
@@ -68,7 +68,7 @@ U.sandwich <- function(Zbeta, Z, Y, link, W=NULL)
     if(!is.null(W))
     {
       U<-W * U
-      U.diff <- -t(Z)%*% diag(W) %*%(Z)
+      U.diff <- -t(W * Z) %*%(Z)
     }
     else
     {
@@ -79,7 +79,7 @@ U.sandwich <- function(Zbeta, Z, Y, link, W=NULL)
   {
     stop(paste("Unsupported link function for Uforposandwich.default:"), link)
   }
-  
+
   rv<-list(U=U, U.diff=U.diff, fv=fv, shared.factor=1, switched.factor=1, self.factor=1)
   return(rv)
 }
@@ -96,10 +96,10 @@ U.score <- function(Zbeta, Z, Y, link, W=NULL)
     warning("Currently, weights are not supported in Uforposandwich.fakeH0. They will be ignored.")
   }
   Zbeta <- c(Zbeta)
-  
+
   tZ<-t(Z)
   fakeU<-t(solve(tZ %*% Z) %*% tZ)
-  
+
   rv<-list(U=fakeU, U.diff=NULL, fv=Zbeta, shared.factor=1/12, switched.factor=-1/12, self.factor=1/4)
   return(rv)
 }


### PR DESCRIPTION
Hi there, 

I studied the structure of this package, although the manual says that adding weights to the pim model is not implemented, I found the essential parameter & vcov estimating scripts did indeed include the functionality of having weights. 

I made changes to:
* "pim.R" - so it will create new pim class with weights slot
* "pim.class.R" - add weights slot to the class
* "pim.fit.R" - pass weights to the estimF()
* "Estimators.R" - add weights argument to estimator.nleqslv(), and pass weights to construct()

Please let me know if I can help more with this. 

Best,
Li
 
